### PR TITLE
[Monitoring] Add a simple Icinga check

### DIFF
--- a/bin/check_fixmystreet
+++ b/bin/check_fixmystreet
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+
+use strict;
+use lib '/usr/lib/nagios/plugins';
+use utils qw(%ERRORS);
+use Getopt::Long;
+
+BEGIN {
+    use File::Basename qw(dirname);
+    use File::Spec;
+    my $d = dirname(File::Spec->rel2abs($0));
+    require "$d/../../fixmystreet/setenv.pl";
+}
+
+use FixMyStreet::DB;
+use FixMyStreet::Script::Reports;
+use Open311::PostServiceRequestUpdates;
+
+my $reports = 10;
+my $updates = 0;
+
+GetOptions(
+    "reports=i" => \$reports,
+    "updates=i" => \$updates,
+);
+
+sub unsent_report_count {
+    my $params = FixMyStreet::Script::Reports::construct_query(1);
+    my $unsent = FixMyStreet::DB->resultset('Problem')->search($params);
+
+    return $unsent->count;
+}
+
+sub unsent_update_count {
+    my $updates = Open311::PostServiceRequestUpdates->new();
+    my $bodies = $updates->fetch_bodies;
+    my $params = $updates->construct_query(1);
+    my $u = FixMyStreet::DB->resultset("Comment")
+       ->to_body([ keys %$bodies ])
+       ->search({ "me.confirmed" => { '<', \"current_timestamp - '5 minutes'::interval" } })
+       ->search($params, { join => "problem" });
+
+    return $u->count;
+}
+
+my $unsent_reports = unsent_report_count();
+my $unsent_updates = unsent_update_count();
+
+my @errors;
+
+push @errors, "$unsent_reports reports"
+    if $unsent_reports > $reports;
+
+push @errors, "$unsent_updates updates"
+    if $unsent_updates > $updates;
+
+if (scalar @errors) {
+    print "WARNING: there are ", join(' and ', @errors), " pending\n";
+    exit $ERRORS{WARNING};
+}
+
+print "OK: there are $unsent_reports reports and $unsent_updates updates pending.\n";
+exit $ERRORS{OK};


### PR DESCRIPTION
This adds an Icinga/Nagios check for unsent reports and updates. Thresholds
can be set using `--reports` and `--updates` options, which default to 50
and 0, respectively.

The current internal check includes checks for times of last sent reports, although these don't seem to ever trigger any action from us we can look at porting these across too - this is just a start to get the updates being monitored, while we look at monitoring more generally.