### PR TITLE
GOV.UK stylesheet generation.

### DIFF
--- a/bin/govuk-css
+++ b/bin/govuk-css
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Assume fixmystreet and fixmystreet.com repos are siblings
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+FMS="$DIR/../fixmystreet"
+
+echo "Compiling GOV.UK CSS"
+$FMS/bin/cron-wrapper perl $DIR/bin/make_css $DIR/css/radios.scss $FMS/web/vendor/govuk-frontend/radios.css
+$FMS/bin/cron-wrapper perl $DIR/bin/make_css $DIR/css/forms.scss $FMS/web/vendor/govuk-frontend/forms.css

--- a/bin/make_css
+++ b/bin/make_css
@@ -3,11 +3,18 @@
 use strict;
 use warnings;
 
+use File::Basename qw(dirname);
+use File::Spec;
 use CSS::Sass;
 use Path::Tiny;
 use Try::Tiny;
 
-my $sass = CSS::Sass->new(output_style => SASS_STYLE_COMPRESSED);
+my $root = dirname(File::Spec->rel2abs($0));
+
+my $sass = CSS::Sass->new(
+    include_paths => ["$root/../../govuk-frontend/src"],
+    output_style => SASS_STYLE_COMPRESSED
+);
 
 my $file = shift;
 my $output_file = shift;

--- a/css/forms.scss
+++ b/css/forms.scss
@@ -1,0 +1,31 @@
+// Only output things currently used/needed
+$govuk-font-family: unquote("");
+$_spacing-directions: ('bottom');
+$govuk-text-colour: unquote("");
+$govuk-print-text-colour: unquote("");
+
+@import "govuk/base";
+
+@import "govuk/core/lists";
+@import "govuk/core/typography";
+
+@import "govuk/objects/form-group";
+@import "govuk/objects/grid";
+
+@import "govuk/components/button/index";
+@import "govuk/components/checkboxes/index";
+@import "govuk/components/date-input/index";
+@import "govuk/components/error-message/index";
+@import "govuk/components/error-summary/index";
+@import "govuk/components/fieldset/index";
+@import "govuk/components/hint/index";
+@import "govuk/components/input/index";
+@import "govuk/components/label/index";
+@import "govuk/components/panel/index";
+@import "govuk/components/radios/index";
+@import "govuk/components/select/index";
+@import "govuk/components/summary-list/index";
+@import "govuk/components/textarea/index";
+
+@import "govuk/utilities/visually-hidden";
+@import "govuk/overrides/spacing";

--- a/css/radios.scss
+++ b/css/radios.scss
@@ -1,0 +1,13 @@
+// Output the variable so that it can be set in FMS stylesheets
+$govuk-focus-colour: unquote('$govuk-focus-colour');
+
+@import "govuk/base";
+
+@mixin govuk-typography-common($font-family: $govuk-font-family) {}
+// Want to drop sizing, but need to keep line-height so things line up
+@mixin govuk-typography-responsive($size, $override-line-height: false, $important: false) {
+    line-height: 1.25;
+}
+@mixin govuk-text-colour() {}
+
+@import "govuk/components/radios/index";


### PR DESCRIPTION
This script/sass files will generate the govuk-based CSS (well, in one case it technically generates sass) currently used by the FixMyStreet repo. It assumes you have a directory in which you have the fixmystreet, fixmystreet.com and govuk-frontend repos all checked out together.
radios is used by the core FMS style (for the new category selection), and forms is used by the waste/noise pages.
Is quite a bit smaller than including the whole frontend CSS file.