### PR TITLE
[BEDS] Add grit bin layer

### DIFF
--- a/layers/centralbeds.map
+++ b/layers/centralbeds.map
@@ -76,4 +76,22 @@ MAP
     END
   END #layer
 
+  LAYER
+    NAME "SaltBins"
+    METADATA
+      "wfs_title"         "SaltBins" ##REQUIRED
+      "gml_unit id_alias" "unit_id"
+      "gml_include_items" "unit id"
+      "gml_featureid"     "unit id" ## REQUIRED
+      "wfs_enable_request" "*"
+      "wfs_getfeature_formatlist" "geojson"
+    END
+    TYPE POINT
+    STATUS ON
+    DATA 'centralbeds/CBC Salt Bins 19122023'
+    PROJECTION
+      "init=epsg:27700"
+    END
+  END #layer
+
 END #mapfile


### PR DESCRIPTION
Adds salt bin layer at request of council. Server side branch name is the same for moving the Salt bin category out of subcategory and triggering the map layer

https://mysocietysupport.freshdesk.com/a/tickets/3676