### PR TITLE
[Bromley] Switch to GeoPackage for the Drains layer

### DIFF
--- a/layers/bromley.map
+++ b/layers/bromley.map
@@ -165,7 +165,9 @@ MAP
     END
     TYPE POINT
     STATUS ON
-    DATA 'bromley/KaarbonTechGulliesMarch22Trim'
+    CONNECTIONTYPE OGR
+    CONNECTION 'bromley/KaarbonTechGullies.gpkg'
+    DATA 'gullies'
     PROJECTION
       "init=epsg:27700"
     END


### PR DESCRIPTION
This has two benefits:
1. Removes the date from the datasource filename
2. De-clutters the layers directory by using a single GeoPackage file

The structure of the GeoPackage matches that of the previous shapefiles, so it should continue to work as it did before.

Part of https://github.com/mysociety/societyworks/issues/4754