### PR TITLE
[Bucks] Temporary snapshot of Car Parks and Speed limits

### DIFF
--- a/layers/bucks.map
+++ b/layers/bucks.map
@@ -340,4 +340,41 @@ END
     END
   END #layer
 
+  LAYER
+    NAME "BC_CAR_PARKS"
+    METADATA
+      "wfs_title"         "Car Parks" ##REQUIRED
+      "wfs_srs"           "EPSG:3857 EPSG:27700" ## REQUIRED
+      "gml_include_items" "Street_nam"
+      "gml_geometries"    "Shape"
+      "gml_Street_nam_alias" "OBJECTID"
+      "wfs_enable_request" "*"
+    END
+    TYPE POLYGON
+    STATUS ON
+    DATA 'bucks/CAR_PARKS'
+    PROJECTION
+      "init=epsg:27700"
+    END
+  END #layer
+
+  LAYER
+    NAME "OS_HIGHWAYS_SPEED"
+    METADATA
+      "wfs_title"         "Highways Speed" ##REQUIRED
+      "wfs_srs"           "EPSG:3857 EPSG:27700" ## REQUIRED
+      "gml_include_items" "speed,os_link_id" ## Optional (serves all attributes for layer)
+      "gml_featureid"     "os_link_id" ## REQUIRED
+      "gml_geometries"    "Shape"
+      "gml_os_link_id_alias" "OBJECTID"
+      "wfs_enable_request" "*"
+    END
+    TYPE LINE
+    STATUS ON
+    DATA 'bucks/OS_HIGHWAYS_SPEED'
+    PROJECTION
+      "init=epsg:27700"
+    END
+  END #layer
+
 END #mapfile


### PR DESCRIPTION
Downtime for Bucks mapserver needs coverage from us via snapshots of map and speed limit data

Changes to asset config in same branch name on the server - map files on staging tilma (CAR_PARKS map layer edited as original Car Parks layer had an & in a car park name string which caused an error).

https://mysocietysupport.freshdesk.com/a/tickets/6337