### PR TITLE
[Central Beds] Migrate some asset layers to Aurora.

### DIFF
--- a/layers/centralbeds.map
+++ b/layers/centralbeds.map
@@ -39,22 +39,19 @@ MAP
     END
   END #layer
 
-  # It doesn't appear possible to include field with spaces
-  # in the WFS output, so the original shapefile was 
-  # processed as follows (photos may be used in the future):
-  # $ ogr2ogr StreetLighting.shp Street\ Lighting.shp -sql "SELECT ogc_fid, \"lighting c\" AS lighting_c, photo01, photo02, photo03, photo04, photo05, photo06 FROM \"Street Lighting\""
   LAYER
     NAME "StreetLighting"
     METADATA
-      "wfs_title"         "StreetLighting" ##REQUIRED
-      "gml_include_items" "ogc_fid,lighting_c,eqno,asset"
-      "gml_featureid"     "ogc_fid" ## REQUIRED
-      "wfs_enable_request" "*"
+      "wfs_title"           "StreetLighting" ##REQUIRED
+      "gml_include_items"   "unit_id,asset_ref"
+      "gml_asset_ref_alias" "label"
+      "gml_featureid"       "unit_id" ## REQUIRED
+      "wfs_enable_request"  "*"
       "wfs_getfeature_formatlist" "geojson"
     END
     TYPE POINT
     STATUS ON
-    DATA 'centralbeds/StreetLighting'
+    DATA 'centralbeds/aurora/LightingPoint'
     PROJECTION
       "init=epsg:27700"
     END

--- a/layers/centralbeds.map
+++ b/layers/centralbeds.map
@@ -77,16 +77,15 @@ MAP
   LAYER
     NAME "SaltBins"
     METADATA
-      "wfs_title"         "SaltBins" ##REQUIRED
-      "gml_unit id_alias" "unit_id"
-      "gml_include_items" "unit id"
-      "gml_featureid"     "unit id" ## REQUIRED
+      "wfs_title"          "SaltBins" ##REQUIRED
+      "gml_include_items"  "unit_id"
+      "gml_featureid"      "unit_id" ## REQUIRED
       "wfs_enable_request" "*"
       "wfs_getfeature_formatlist" "geojson"
     END
     TYPE POINT
     STATUS ON
-    DATA 'centralbeds/CBC Salt Bins 19122023'
+    DATA 'centralbeds/aurora/GritBin'
     PROJECTION
       "init=epsg:27700"
     END

--- a/layers/centralbeds.map
+++ b/layers/centralbeds.map
@@ -24,16 +24,16 @@ MAP
   LAYER
     NAME "Highways"
     METADATA
-      "wfs_title"         "Highways" ##REQUIRED
-      "gml_include_items" "ogc_fid,adoption,usrn_type_"
-      "gml_usrn_type__alias" "streetref1"
-      "gml_featureid"     "ogc_fid" ## REQUIRED
-      "wfs_enable_request" "*"
+      "wfs_title"           "Highways" ##REQUIRED
+      "gml_include_items"   "unit_id,asset_ref"
+      "gml_asset_ref_alias" "usrn"
+      "gml_featureid"       "unit_id" ## REQUIRED
+      "wfs_enable_request"  "*"
       "wfs_getfeature_formatlist" "geojson"
     END
     TYPE LINE
     STATUS ON
-    DATA 'centralbeds/Highways2025'
+    DATA 'centralbeds/aurora/Street'
     PROJECTION
       "init=epsg:27700"
     END


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/5292.

See https://github.com/mysociety/tilma/pull/40 for how asset data is fetched and processed.

Relevant servers repo commits for corresponding FMS asset layer configuration:
* `644e2` Use new `usrn` attribute for highways layer instead of older `streetref1`.
* `516aa4` Start sending asset IDs for salt bin reports.
* `9bf47` Stop sending asset IDs for trees. Asset IDs are now actually sent to Aurora rather than just including in the description text and, since we are still using kaarbontech owned tree data, sending would break without this.
* `60739` Update street lighting layer to use new `unit_id` and `label` attributes.