### PR TITLE
Update install script to support macos ARM.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,10 +1,17 @@
 if [ ! -e ../node ]; then
   cd ..
-  curl -O https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-x64.tar.xz
-  unxz node-v8.9.1-linux-x64.tar.xz 
-  tar xf node-v8.9.1-linux-x64.tar 
-  rm node-v8.9.1-linux-x64.tar 
-  mv node-v8.9.1-linux-x64 node
+  OS=$(uname -s | tr A-Z a-z)
+  ARCH=$(uname -m)
+  case "$ARCH" in
+    x86_64) NODE_ARCH="x64" ;;
+    arm64) NODE_ARCH="arm64" ;;
+    *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+  esac
+  curl -O https://nodejs.org/dist/v8.9.1/node-v8.9.1-${OS}-${NODE_ARCH}.tar.xz
+  unxz node-v8.9.1-${OS}-${NODE_ARCH}.tar.xz 
+  tar xf node-v8.9.1-${OS}-${NODE_ARCH}.tar 
+  rm node-v8.9.1-${OS}-${NODE_ARCH}.tar 
+  mv node-v8.9.1-${OS}-${NODE_ARCH} node
   export PATH=$(pwd)/node/bin:$PATH
   cd fixmystreet.com
   npm install penthouse


### PR DESCRIPTION
Motivated by testing vhost package building, using the `critical-css` script, on a macbook.

Still able to deploy on a server as normal.