### PR TITLE
[Rutland] Add map layer with lighting definition

### DIFF
--- a/layers/rutland.map
+++ b/layers/rutland.map
@@ -1,0 +1,32 @@
+MAP
+  NAME "Rutland"
+  STATUS ON
+  EXTENT -180 -90 180 90
+  SHAPEPATH "../../layers"
+
+  OUTPUTFORMAT
+    NAME "geojson"
+    DRIVER "OGR/GEOJSON"
+    MIMETYPE "application/json; subtype=geojson"
+    FORMATOPTION "STORAGE=stream"
+    FORMATOPTION "FORM=SIMPLE"
+  END
+
+  LAYER
+    NAME "lighting"
+    METADATA
+      "wfs_title"         "Lighting"
+      "wfs_srs"           "EPSG:3857 EPSG:27700"
+      "gml_include_items" "unique_id,unit_type"
+      "gml_featureid"     "unique_id"
+      "wfs_enable_request" "*"
+    END
+    TYPE POINT
+    STATUS ON
+    DATA 'rutland/street_lighting'
+    PROJECTION
+      "init=epsg:27700"
+    END
+  END #layer
+
+END #mapfile


### PR DESCRIPTION
Tilma has already been updated to initialise the map layer and for the Kaarbontech server to be proxied.

Please also check rutland-map-layer on servers for actual layers implementation for FMS

https://github.com/mysociety/societyworks/issues/5401